### PR TITLE
Add simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+PREFIX ?= /usr
+DATADIR ?= $(PREFIX)/share
+THEMESDIR ?= $(DATADIR)/themes
+NAME ?= plano
+TDIR ?= $(DESTDIR)/$(THEMESDIR)/$(NAME)
+
+install:
+	mkdir -p $(TDIR)
+	cp -r gtk-2.0 $(TDIR)/
+	cp -r gtk-3.0 $(TDIR)/
+	cp -r gnome-shell $(TDIR)/
+	cp -r openbox-3 $(TDIR)/
+	cp -r xfwm4 $(TDIR)/
+
+


### PR DESCRIPTION
I packaged plano-theme as debs (https://github.com/mikhailnov/plano-theme/tree/master/debian) and created a simple Makefile which simplified packaging, this Makefile can be usefull for outher purposes and other packagers.